### PR TITLE
Adds draggable grid layout to form builder canvas

### DIFF
--- a/src/app/pages/reactive-form-builder/canvas/canvas.component.css
+++ b/src/app/pages/reactive-form-builder/canvas/canvas.component.css
@@ -105,3 +105,40 @@
   color: #aaa;
   padding: 1rem;
 }
+
+/* --- NEW STYLES --- */
+
+/* Style the grid container itself */
+.canvas-item.is-group {
+  /* This now applies to form-group and grid-layout */
+  border-color: #1890ff;
+  background-color: #f7faff;
+}
+
+.grid-layout-content {
+  width: 100%;
+}
+
+.grid-drop-zone {
+  display: grid;
+  gap: 1rem; /* Spacing between grid items */
+}
+
+.grid-column {
+  background-color: #fff;
+  min-height: 80px;
+  padding: 1rem;
+  border: 1px dashed #b1d9ff;
+  border-radius: 4px;
+}
+
+/* We want children of a grid to take up the full cell height */
+.canvas-item-wrapper.is-grid-child {
+  height: 100%;
+  margin-bottom: 0; /* Remove default bottom margin */
+}
+
+.is-grid-child .canvas-item {
+  height: 100%;
+  box-sizing: border-box;
+}

--- a/src/app/pages/reactive-form-builder/canvas/canvas.component.html
+++ b/src/app/pages/reactive-form-builder/canvas/canvas.component.html
@@ -1,76 +1,98 @@
+
 <div class="canvas-header">Form Canvas</div>
-    <div
-      cdkDropList
-      id="canvas-list"
-      [cdkDropListData]="formState.canvasItems()"
-      (cdkDropListDropped)="onDrop($event)"
-      class="canvas-drop-zone"
-    >
-      @for (item of formState.canvasItems(); track item.id) {
-        <div class="canvas-item-wrapper" cdkDrag>
-          <!-- Using a template to render items, allows for recursion -->
-          <ng-container
-            *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"
-          ></ng-container>
-        </div>
-      } @empty {
-        <div class="empty-canvas-message">
-          Drop items from the toolbox here
+<div
+  cdkDropList
+  id="canvas-list"
+  [cdkDropListData]="formState.canvasItems()"
+  [cdkDropListConnectedTo]="formState.canvasDropListIds()"
+  (cdkDropListDropped)="onDrop($event)"
+  class="canvas-drop-zone"
+>
+  @for (item of formState.canvasItems(); track item.id) {
+    <div class="canvas-item-wrapper" cdkDrag>
+      <!-- Using a template to render items, allows for recursion -->
+      <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
+    </div>
+  } @empty {
+    <div class="empty-canvas-message">
+      Drop items from the toolbox here
+    </div>
+  }
+</div>
+
+<!-- Recursive Template for rendering items -->
+<ng-template #itemTemplate let-item>
+  <div class="canvas-item" [class.is-group]="item.type === 'form-group' || item.type === 'grid-layout'">
+    <!-- Render based on item type -->
+    @switch (item.type) {
+      @case ('text-input') {
+        <div class="item-content">
+          <label>{{ item.label }}</label>
+          <input type="text" [placeholder]="item.placeholder" disabled />
         </div>
       }
-    </div>
-
-    <!-- Recursive Template for rendering items -->
-    <ng-template #itemTemplate let-item>
-      <div class="canvas-item" [class.is-group]="item.type === 'form-group'">
-        <!-- Render based on item type -->
-        @switch (item.type) {
-          @case ('text-input') {
-            <div class="item-content">
-              <label>{{ item.label }}</label>
-              <input type="text" [placeholder]="item.placeholder" disabled />
-            </div>
-          }
-          @case ('checkbox') {
-            <div class="item-content checkbox">
-              <input type="checkbox" disabled />
-              <label>{{ item.label }}</label>
-            </div>
-          }
-          @case ('label') {
-            <p class="item-content label-text">{{ item.text }}</p>
-             <!-- <p-button icon="pi pi-trash"  [outlined]="true" severity="danger" size="small" (click)="deleteControl(item)" /> -->
-          }
-          @case ('form-group') {
-            <div class="item-content group-content">
-              <strong class="group-title">{{ item.formGroupName }}</strong>
-              <!-- This is the nested drop zone -->
-              <div
-                cdkDropList
-                [id]="item.id"
-                [cdkDropListData]="item.children"
-                (cdkDropListDropped)="onDrop($event, item)"
-                class="group-drop-zone"
-              >
-                @for (child of item.children; track child.id) {
-                  <div class="canvas-item-wrapper" cdkDrag>
-                    <ng-container
-                      *ngTemplateOutlet="itemTemplate; context: { $implicit: child }"
-                    ></ng-container>
+      @case ('checkbox') {
+        <div class="item-content checkbox">
+          <input type="checkbox" disabled />
+          <label>{{ item.label }}</label>
+        </div>
+      }
+      @case ('label') {
+        <p class="item-content label-text">{{ item.text }}</p>
+        <!-- <p-button icon="pi pi-trash"  [outlined]="true" severity="danger" size="small" (click)="deleteControl(item)" /> -->
+      }
+      @case ('form-group') {
+        <div class="item-content group-content">
+          <strong class="group-title">{{ item.formGroupName }}</strong>
+          <!-- This is the nested drop zone -->
+          <div cdkDropList [id]="item.id" [cdkDropListData]="item.children" [cdkDropListConnectedTo]="formState.canvasDropListIds()" (cdkDropListDropped)="onDrop($event)"
+            class="group-drop-zone">
+            @for (child of item.children; track child.id) {
+              <div class="canvas-item-wrapper" cdkDrag>
+                <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: child }"></ng-container>
+              </div>
+            } @empty {
+              <div class="empty-group-message">Drop items here</div>
+            }
+          </div>
+        </div>
+      }
+      <!-- --- NEW RENDER LOGIC --- -->
+      @case ('grid-layout') {
+        <div class="item-content grid-layout-content">
+          <strong class="group-title">Layout container</strong>
+          <div cdkDropList [id]="item.id" [cdkDropListData]="item.children"
+            [cdkDropListConnectedTo]="formState.canvasDropListIds()" (cdkDropListDropped)="onDrop($event)"
+            class="grid-drop-zone">
+            @for (row of getGridCells(item.rows, item.columns); track $index) {
+              <div class="grid-row flex w-full">
+                @for (cell of row; track $index) {
+                  <div class="grid-column flex-1">
+                    @if (item.children && item.children.length > cell.index) {
+                      <div class="canvas-item-wrapper is-grid-child" cdkDrag>
+                        <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item.children[cell.index] }"></ng-container>
+                      </div>
+                    } @else {
+                      <div class="empty-group-message">
+                        Drop controls here {{cell | json}}
+                      </div>
+                    }
                   </div>
-                } @empty {
-                  <div class="empty-group-message">Drop items here</div>
                 }
               </div>
-            </div>
-          }
-        }
-        <div class="item-handle" cdkDragHandle>
-            <span class="mr-3">
-                <!-- <app-button-demo  btnSeverity="warn" btnText="🗑️ delete"/> -->
-                 <p-button icon="pi pi-trash"  [outlined]="true" severity="danger" size="small" (click)="deleteControl(item)" />
-            </span>
-           <span>⠿</span> 
+            }
+          </div>
         </div>
-      </div>
-    </ng-template>
+      }
+
+      
+    }
+    <div class="item-handle" cdkDragHandle>
+      <span class="mr-3">
+        <!-- <app-button-demo  btnSeverity="warn" btnText="🗑️ delete"/> -->
+        <p-button icon="pi pi-trash" [outlined]="true" severity="danger" size="small" (click)="deleteControl(item)" />
+      </span>
+      <span>⠿</span>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/pages/reactive-form-builder/models/canvas-item.model.ts
+++ b/src/app/pages/reactive-form-builder/models/canvas-item.model.ts
@@ -3,14 +3,16 @@ export type CanvasItem =
   | FormInputItem
   | FormCheckboxItem
   | FormLabelItem
-  | FormGroupItem;
+  | FormGroupItem
+  | GridLayoutItem;
 
 // The different types of items, used for rendering and logic
 export type CanvasItemType =
   | 'text-input'
   | 'checkbox'
   | 'label'
-  | 'form-group';
+  | 'form-group'
+  | 'grid-layout';
 
 // Base interface with common properties for all canvas items
 export interface BaseCanvasItem {
@@ -42,4 +44,11 @@ export interface FormGroupItem extends BaseCanvasItem {
   formGroupName: string;
   // A form group can contain other items, enabling nesting
   children: CanvasItem[];
+}
+
+export interface GridLayoutItem extends BaseCanvasItem {
+  type: 'grid-layout';
+  columns: number; // The number of columns in the grid
+  rows: number;
+  children: CanvasItem[]; // The controls nested inside the grid
 }

--- a/src/app/pages/reactive-form-builder/toolbox/toolbox.component.ts
+++ b/src/app/pages/reactive-form-builder/toolbox/toolbox.component.ts
@@ -61,5 +61,15 @@ export class ToolboxComponent {
         };
       },
     },
+    {
+      name: 'Grid Layout',
+      type: 'grid-layout',
+      build: () => ({
+        type: 'grid-layout',
+        columns: 2, // Default to a 2-column layout
+        rows: 3,
+        children: [],
+      }),
+    }
   ]);
 }

--- a/src/app/shared/components/header/header/header.component.ts
+++ b/src/app/shared/components/header/header/header.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MegaMenuItem } from 'primeng/api';
-import { MegaMenu } from 'primeng/megamenu';
+// import { MegaMenu } from 'primeng/megamenu';
 import { ButtonModule } from 'primeng/button';
 import { CommonModule } from '@angular/common';
 import { AvatarModule } from 'primeng/avatar';
@@ -9,7 +9,7 @@ import { LoginComponent } from "../../../../pages/auth/login/login.component";
 
 @Component({
   selector: 'app-header',
-  imports: [MegaMenu, ButtonModule, CommonModule, AvatarModule, LoginComponent],
+  imports: [ButtonModule, CommonModule, AvatarModule, LoginComponent],
   templateUrl: './header.component.html',
   styleUrl: './header.component.css'
 })


### PR DESCRIPTION
Introduces a configurable grid layout component, enabling users to visually arrange controls in rows and columns within the form builder. Updates drag-and-drop logic for nested structures and enhances styling and state management to support grid-based layouts.

Relates to #17  